### PR TITLE
allow filename to be nil if not specified

### DIFF
--- a/cli.rb
+++ b/cli.rb
@@ -27,7 +27,6 @@ or
   end
   opts.on('-r [ARG]', '--repository', 'Export only one repository') do |v|
     options[:repository] = v
-    options[:filename] ||= v + '.zip'
   end
   opts.on('-h', '--help', 'Show this message') do |v|
     puts opts


### PR DESCRIPTION
Specifying the filename compromises the logic that handles a nil
filename in GTBI::Export generate method.
