### PR TITLE
Map labels that are not used for type and priority to components

### DIFF
--- a/lib/github-to-bitbucket-issues/export.rb
+++ b/lib/github-to-bitbucket-issues/export.rb
@@ -31,6 +31,7 @@ module GTBI
       @issues = []
       @comments = []
       @milestones = []
+      @components = []
     end
 
     def generate
@@ -72,7 +73,7 @@ module GTBI
           :default_milestone => nil,
           :default_version => nil
         },
-        :components => [],
+        :components => @components,
         :versions => []
       })
     end
@@ -91,6 +92,7 @@ module GTBI
       %w(open closed).each do |state|
         @issues += download_all_of("issue", {:state => state})
       end
+      @components += @issues.map { |a| a[:component] }.compact.uniq
     end
 
     def download_comments

--- a/lib/github-to-bitbucket-issues/export.rb
+++ b/lib/github-to-bitbucket-issues/export.rb
@@ -92,7 +92,7 @@ module GTBI
       %w(open closed).each do |state|
         @issues += download_all_of("issue", {:state => state})
       end
-      @components += @issues.map { |a| a[:component] }.compact.uniq
+      @components += @issues.map { |a| a[:component] }.compact.uniq.map { |a| { :name => a } }
     end
 
     def download_comments

--- a/lib/github-to-bitbucket-issues/formatters/issue.rb
+++ b/lib/github-to-bitbucket-issues/formatters/issue.rb
@@ -4,7 +4,7 @@ module GTBI
       def formatted
         {
           :assignee => get_assignee(@raw),
-          :component => nil,
+          :component => get_component(@raw),
           :content => @raw.body || " ",
           :content_updated_on => @raw.updated_at,
           :created_on => @raw.updated_at,
@@ -60,6 +60,13 @@ module GTBI
         else
           'major'
         end
+      end
+
+      # Fetching the component from the labels is limited is that only one component is allowed, so we take the first label
+      # Ignore labels common in GitHub that are used for other things, such as type and priority
+      KNOWN_LABELS = ['enhancement','proposal','task','bug','trivial','minor','critical','blocker','major']
+      def get_component(issue)
+        issue.labels.map { |a| a[:name] }.reject { |a| KNOWN_LABELS.include?(a) }[0]
       end
 
       def get_milestone(issue)


### PR DESCRIPTION
Labels can be used to identify components of the application. This patch treats labels that aren't recognized as issue type or priority as components. Unfortunately BitBucket only allows one component per issue, so the first label (that isn't type or priority) is taken.
